### PR TITLE
fix: guard mac java config in zsh

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -252,8 +252,12 @@ export TTY_CURSOR_COLOR="#ffbd69"
 # Pi
 export PATH="/home/labadmin/.local/share/pi-node/node-v22.22.3-linux-x64/bin:$PATH"
 
-# Mac-style clipboard aliases
-alias pbcopy='xclip -selection clipboard'
-alias pbpaste='xclip -selection clipboard -o'
+# Mac-style clipboard aliases on Linux
+if [[ "$IS_MAC" != "true" ]]; then
+    alias pbcopy='xclip -selection clipboard'
+    alias pbpaste='xclip -selection clipboard -o'
+fi
 
-export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+if [[ "$IS_MAC" == "true" ]]; then
+    export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+fi


### PR DESCRIPTION
## Summary
- guard the macOS-only Java initialization in `zsh/.zshrc`
- keep the Linux clipboard aliases on Ubuntu only
- remove the `source ~/.zshrc` error on `mgmt-01` caused by `/usr/libexec/java_home`

## Validation
- `zsh -n zsh/.zshrc`
- sourced the updated shell config on `mgmt-01` without the previous Java path error

## Files
- zsh/.zshrc
